### PR TITLE
Update Google Maps API version default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Once the application starts, the user may interact with the Google maps API [as 
 Aspects of the Google Maps Installation can be customized, by supplying environment variables to the server process.
 
 * `GOOGLE_MAPS_URL` - The URL to the API script.  Defaults to `https://maps.googleapis.com/maps/api/js`.
-* `GOOGLE_MAPS_VERSION` - The version of the API script. Defaults to `3.22`.
+* `GOOGLE_MAPS_VERSION` - The version of the API script. Defaults to `3.31`.
 * `GOOGLE_MAPS_API_KEY` - The Google Maps API Key.  Defaults to none, which is OK when running your server on localhost, but will require a key when deploying to a remote server.
 
 ## Installation

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(/*environment, appConfig */) {
   let env = {};
   env['ember-simple-google-maps'] = {
     url: process.env.GOOGLE_MAPS_URL || 'https://maps.googleapis.com/maps/api/js',
-    version: process.env.GOOGLE_MAPS_VERSION || '3.22',
+    version: process.env.GOOGLE_MAPS_VERSION || '3.31',
     apiKey: process.env.GOOGLE_MAPS_API_KEY || ''
   }
 


### PR DESCRIPTION
Versions of Google Maps API <= 3.29 have been retired and do not work.
Updates default version to 3.31